### PR TITLE
Improve reliability of "deploy to Render" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ This template can be used to deploy your Next.js application as a Node.js server
 1. Fork this repo.
 1. In your new repo, click the button below.
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+<a href="https://render.com/deploy" referrerpolicy="no-referrer-when-downgrade" rel="nofollow">
+  <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" />
+</a>
 
 Note: The button uses the `render.yaml` file in this repo to deploy your app. For more information about `render.yaml`, see [Render's guide](https://docs.render.com/infrastructure-as-code).
 


### PR DESCRIPTION
GitHub sets `Referrer Policy: strict-origin-when-cross-origin`, which interacts oddly with Chrome and our Referrer detection. _Sometimes_ Chrome will only send the origin (as set by the policy) but other times it will send the full referrer.

This appears to be a bug (or feature?) in Chrome - The first visit will only send the origin, but navigating back and clicking again will send the full referrer.

Thankfully the anchor tag supports explicitly setting a `referrerpolicy`, telling the browser to always send the full referrer for this link.